### PR TITLE
Add permissions to Github Actions workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,6 @@
 name: Unit tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main, next]


### PR DESCRIPTION
Potential fix for [https://github.com/notus-sh/dragonfly-cache/security/code-scanning/1](https://github.com/notus-sh/dragonfly-cache/security/code-scanning/1)

To fix this problem, the workflow should include a `permissions` key set to the least privilege required for the tasks at hand. Since this workflow is running unit tests and does not appear to need to write to the repository, create issues, or perform any other write operations, it is appropriate to set `contents: read` as the workflow-level permission block. This should be added at the top level of the workflow—outside the `jobs:` block—so it applies to all jobs by default. 

This can be accomplished by adding the following lines after the `name: Unit tests` line and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are necessary for YAML GitHub Actions workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
